### PR TITLE
Fix URL of deployed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elk Development Kit Documentation
 
-To read the documentation, follow this link: https://elk-audio.github.io/elk-docs/
+To read the documentation, follow this link: https://elk-audio.github.io/elk-docs/html/
 
 This repository contains the source files, and generated HTML output, for the Elk Development Kit Documentation.
 


### PR DESCRIPTION
Unfortunately, when navigating to the the URL https://elk-audio.github.io/elk-docs/ it returned error 404

Maybe it should be better fixed on server side with a redirect rule?